### PR TITLE
CSPII-9006: Support special characters for password field

### DIFF
--- a/nuxeo-drive-client/nxdrive/client/base_automation_client.py
+++ b/nuxeo-drive-client/nxdrive/client/base_automation_client.py
@@ -628,7 +628,14 @@ class BaseAutomationClient(BaseClient):
         return path
 
     def _update_auth(self, password=None, token=None):
-        """Select the most appropriate auth headers based on credentials"""
+        """
+        When username retrieved from database, check for unicode and convert to string.
+        Scenario: Unlink from DM and provide credentials from DS Client
+        Note: base64Encoding for unicode type will fail, hence converting to string
+        """
+        if self.user_id and isinstance(self.user_id, unicode):
+            self.user_id = unicode(self.user_id).encode('utf-8')
+        # Select the most appropriate auth headers based on credentials
         if token is not None:
             self.auth = ('X-Authentication-Token', token)
         elif password is not None:

--- a/nuxeo-drive-client/nxdrive/wui/dialog.py
+++ b/nuxeo-drive-client/nxdrive/wui/dialog.py
@@ -251,7 +251,12 @@ class WebDriveApi(QtCore.QObject):
         return Promise(self._update_password, uid, password)
 
     def _update_password(self, uid, password):
-        password = str(password)
+        """
+        Convert password from unicode to string to support utf-8 character
+        scenario: Unlink from DM and provide credentials from DS Client
+        """
+        if password and isinstance(password, QtCore.QString):
+            password = unicode(password).encode('utf-8')
         try:
             from time import sleep
             sleep(5.0)

--- a/nuxeo-drive-client/nxdrive/wui/settings.py
+++ b/nuxeo-drive-client/nxdrive/wui/settings.py
@@ -89,9 +89,13 @@ class WebSettingsApi(WebDriveApi):
         if isinstance(local_folder, QtCore.QString):
             local_folder = str(local_folder.toUtf8()).decode('utf-8')
         url = str(url)
-        username = str(username)
-        password = str(password)
-        name = unicode(name)
+
+        # On first time login convert QString(having special characters) to str
+        if username and isinstance(username, QtCore.QString):
+            username = unicode(username).encode('utf-8')
+        if password and isinstance(password, QtCore.QString):
+            password = unicode(password).encode('utf-8')
+        name = unicode(username)
         if name == '':
             name = None
         binder = namedtuple('binder', ['username', 'password', 'token', 'url', 'no_check', 'no_fscheck'])


### PR DESCRIPTION
Hello @mconstantin,
Non-ascii characters were not encoded and login failed. (Conversion from QTString to String fails)
Fix: By encoding the non-ascii characters in password, then DS client connected successfully.

Please review and merge the fix.
