### PR TITLE
CSPII-8664: Ignore office temp on created event

### DIFF
--- a/nuxeo-drive-client/nxdrive/engine/watcher/local_watcher.py
+++ b/nuxeo-drive-client/nxdrive/engine/watcher/local_watcher.py
@@ -919,6 +919,12 @@ class LocalWatcher(EngineWorker):
                             # Stop the process here
                             return
                         log.debug('Copy paste from %r to %r', from_pair.local_path, rel_path)
+
+                # Check if the file is not a office temp 
+                if not local_info.folderish and is_office_temp_file(file_name):
+                    log.debug("Ignore office tmp files with created event [%s]", file_name)
+                    return
+
                 self._dao.insert_local_state(local_info, parent_rel_path)
                 # An event can be missed inside a new created folder as
                 # watchdog will put listener after it


### PR DESCRIPTION
@mconstantin 
Please review and merge the fix.
The problem appears to be with the **pptAA04.tmp** files getting uploaded to Server upon multiple save(Ctrl+S) on the edited Powerpoint document.

I have created an Integration test case to simulate the scenario using the win32com module, I am not sure if that could be integrated as the simulation opens the Powerpoint Application and does the operation. 

Please refer [**CSPII-8864**](https://jira.sharplabs.com/browse/CSPII-8864) for details on the root cause and the integration test also has been attached in the JIRA.
