### PR TITLE
CSPII-9340: missing logs after auto-update

### DIFF
--- a/nuxeo-drive-client/nxdrive/wui/application.py
+++ b/nuxeo-drive-client/nxdrive/wui/application.py
@@ -586,7 +586,7 @@ class Application(SimpleApplication):
         args = [updated_executable]
         args.extend(sys.argv[1:])
         log.info("Opening subprocess with args: %r", args)
-        subprocess.Popen(args)
+        subprocess.Popen(args, close_fds=True)
 
     def get_mac_app(self):
         return 'ndrive'


### PR DESCRIPTION
After auto-update relaunch newer version of application without inheriting handles from older version of application (process). This ensures the log file is not locked and properly rolls-over at midnight.
