### PR TITLE
CSPII-9407: Fix relative path for temp files in get paths

### DIFF
--- a/nuxeo-drive-client/nxdrive/client/local_client.py
+++ b/nuxeo-drive-client/nxdrive/client/local_client.py
@@ -717,7 +717,13 @@ class LocalClient(BaseClient):
             self.lock_ref(new_parent_ref, locker & 1 | new_locker)
 
     def is_inside(self, abspath):
-        return abspath.startswith(self.base_folder)
+        if abspath.startswith(self.base_folder):
+            return True
+        else:
+            # Computing path for temp file in windows
+            # during remote sync.
+            abspath = abspath.lstrip("\\?")
+            return abspath.startswith(self.base_folder)
 
     def get_path(self, abspath):
         """Relative path to the local client from an absolute OS path"""


### PR DESCRIPTION
Please review and merge the fix.
Temp file location path for the remotely created files doesn't match the base_folder validation and it returns False.
