### PR TITLE
Fix cspii 10276 avoid auto resuming while engine is offline

### DIFF
--- a/nuxeo-drive-client/nxdrive/engine/queue_manager.py
+++ b/nuxeo-drive-client/nxdrive/engine/queue_manager.py
@@ -143,12 +143,13 @@ class QueueManager(QObject):
                   self._max_local_processors, self._max_remote_processors, self._max_generic_processors)
 
     def resume(self):
-        log.debug("Resuming queue")
-        self.enable_local_file_queue(True, False)
-        self.enable_local_folder_queue(True, False)
-        self.enable_remote_file_queue(True, False)
-        self.enable_remote_folder_queue(True, False)
-        self.queueProcessing.emit()
+        if not self._engine.is_offline():
+            log.debug("Resuming queue")
+            self.enable_local_file_queue(True, False)
+            self.enable_local_folder_queue(True, False)
+            self.enable_remote_file_queue(True, False)
+            self.enable_remote_folder_queue(True, False)
+            self.queueProcessing.emit()
 
     def is_paused(self):
         return (not self._local_file_enable or

--- a/nuxeo-drive-client/nxdrive/engine/watcher/local_watcher.py
+++ b/nuxeo-drive-client/nxdrive/engine/watcher/local_watcher.py
@@ -262,7 +262,8 @@ class LocalWatcher(EngineWorker):
         self._metrics['last_local_scan_time'] = current_milli_time() - start_ms
         log.debug("Full scan finished in %dms", self._metrics['last_local_scan_time'])
         self._local_scan_finished = True
-        self._engine.get_queue_manager().resume()
+        if not self._engine.is_offline():
+            self._engine.get_queue_manager().resume()
         self.localScanFinished.emit()
 
     def _scan_handle_deleted_files(self):
@@ -290,7 +291,8 @@ class LocalWatcher(EngineWorker):
         self._suspend_queue()
         self._scan_recursive(info, recursive=False)
         self._scan_handle_deleted_files()
-        self._engine.get_queue_manager().resume()
+        if not self._engine.is_offline():
+            self._engine.get_queue_manager().resume()
 
     def empty_events(self):
         return self._watchdog_queue.empty() and ( not AbstractOSIntegration.is_windows() or

--- a/nuxeo-drive-client/nxdrive/engine/watcher/local_watcher.py
+++ b/nuxeo-drive-client/nxdrive/engine/watcher/local_watcher.py
@@ -262,8 +262,7 @@ class LocalWatcher(EngineWorker):
         self._metrics['last_local_scan_time'] = current_milli_time() - start_ms
         log.debug("Full scan finished in %dms", self._metrics['last_local_scan_time'])
         self._local_scan_finished = True
-        if not self._engine.is_offline():
-            self._engine.get_queue_manager().resume()
+        self._engine.get_queue_manager().resume()
         self.localScanFinished.emit()
 
     def _scan_handle_deleted_files(self):
@@ -291,8 +290,7 @@ class LocalWatcher(EngineWorker):
         self._suspend_queue()
         self._scan_recursive(info, recursive=False)
         self._scan_handle_deleted_files()
-        if not self._engine.is_offline():
-            self._engine.get_queue_manager().resume()
+        self._engine.get_queue_manager().resume()
 
     def empty_events(self):
         return self._watchdog_queue.empty() and ( not AbstractOSIntegration.is_windows() or

--- a/nuxeo-drive-client/nxdrive/tests/common_unit_test.py
+++ b/nuxeo-drive-client/nxdrive/tests/common_unit_test.py
@@ -251,6 +251,8 @@ class UnitTestCase(unittest.TestCase):
         options.autolock_interval = 30
         options.nxdrive_home = self.nxdrive_conf_folder_1
         options.version == __version__
+        options.upload_rate = 300
+        options.download_rate = 300
         self.manager_1 = Manager(options)
         self.connected = False
         self.version = self.manager_1.get_version()
@@ -267,7 +269,6 @@ class UnitTestCase(unittest.TestCase):
             # Remove the engine type for the rest of the test
             self.nuxeo_url = url.split('#')[0]
         self.setUpServer(server_profile)
-
         self.engine_1 = self.manager_1.bind_server(self.local_nxdrive_folder_1, url, self.user_1,
                                                    self.password_1, start_engine=False)
         self.engine_2 = self.manager_2.bind_server(self.local_nxdrive_folder_2, url, self.user_2,

--- a/nuxeo-drive-client/nxdrive/tests/test_engine_offline.py
+++ b/nuxeo-drive-client/nxdrive/tests/test_engine_offline.py
@@ -8,12 +8,13 @@ Files/folders should not sync while engine is paused due to a network error. In 
 '''
 
 from common_unit_test import UnitTestCase
+# To re-use time delay between two successive GetChangeSummary calls
+from common import TEST_DEFAULT_DELAY
 import nxdrive
 from mock import patch
 from urllib2 import URLError
 from time import sleep
 from nxdrive.client.base_automation_client import BaseAutomationClient
-
 
 
 class EngineOffLineTestCase(UnitTestCase):
@@ -32,7 +33,7 @@ class EngineOffLineTestCase(UnitTestCase):
         super(EngineOffLineTestCase, self).setUp()
         # Start engine and wait for Sync
         self.engine_1.start()
-        self.wait_sync(wait_for_async=30)
+        self.wait_sync(wait_for_async=True, timeout=30)
 
     def tearDown(self):
         pass
@@ -49,6 +50,19 @@ class EngineOffLineTestCase(UnitTestCase):
             raise URLError("server is offline in mock_execute:")
         return EngineOffLineTestCase.original_execute(self, *args, **kwargs)
 
+    def wait_for_upload(self, items=[], timeout=30):
+        '''
+            Wait for a list of file/folders to upload
+        '''
+        elapsed = 0
+        not_synced = items
+        while not_synced and elapsed < timeout:
+            sleep(2)
+            elapsed = elapsed + 2
+            states = [self.get_dao_state_from_engine_1(item) for item in items]
+            not_synced = [state for state in states if state and str(state.pair_state) != 'synchronized']
+        return states
+
     @patch.object(nxdrive.client.base_automation_client.BaseAutomationClient, 'fetch_api', mock_fetch_api)
     @patch.object(nxdrive.client.base_automation_client.BaseAutomationClient, 'execute', mock_execute)
     def test_with_mock_server_offline(self):
@@ -64,13 +78,13 @@ class EngineOffLineTestCase(UnitTestCase):
 
         EngineOffLineTestCase.server_online = False
         # Wait for GetChangeSummary to call check_offline method
-        sleep(35)
+        sleep(TEST_DEFAULT_DELAY + 2)
 
         # Create a folder inside user folder and a file inside the folder
         self.local_client_1.make_folder('/', 'FolderA')
         self.local_client_1.make_file('/FolderA', 'TestFile.txt', content="test network failure")
         # Wait for events to be handled
-        sleep(35)
+        sleep(TEST_DEFAULT_DELAY + 2)
 
         # Check pair_state and error_count for the folder/file because it should not try to sync when engine is offline
         test_folder = self.get_dao_state_from_engine_1('/FolderA')
@@ -82,17 +96,13 @@ class EngineOffLineTestCase(UnitTestCase):
 
         # Stop mocking and call original method
         EngineOffLineTestCase.server_online = True
-        # Wait for queue_manager to process for the folder/file
-        sleep(60)
 
-        # pair_state should be 'synchronized' for the folder/file
-        test_folder = self.get_dao_state_from_engine_1('/FolderA')
-        self.assertEqual(test_folder.pair_state, 'synchronized')
-        test_file = self.get_dao_state_from_engine_1('/FolderA/TestFile.txt')
-        self.assertEqual(test_file.pair_state, 'synchronized')
+        # Wait for files to upload
+        states = self.wait_for_upload(items=['/FolderA', '/FolderA/TestFile.txt'])
+        for state in states:
+            self.assertEqual(state.pair_state, 'synchronized')
 
     def test_with_manual_pause_resume(self):
-
         '''
         1. Pause the engine
         2. Create a local folder inside user folder
@@ -101,7 +111,6 @@ class EngineOffLineTestCase(UnitTestCase):
         5. Resume the engine
         4. Check the pair_state when engine is resumed
         '''
-
         # Suspend the engine
         self.engine_1.suspend()
 
@@ -109,7 +118,7 @@ class EngineOffLineTestCase(UnitTestCase):
         self.local_client_1.make_folder('/', 'FolderB')
         self.local_client_1.make_file('/FolderB', 'TestFile1.txt', content="test manual pause and resume")
         # Wait for events to be handled
-        sleep(35)
+        sleep(TEST_DEFAULT_DELAY + 2)
 
         # queue manager will not process for the folder/file when engine is paused and
         # database should not have entries for the folder/file
@@ -120,11 +129,8 @@ class EngineOffLineTestCase(UnitTestCase):
 
         # Resume the engine
         self.engine_1.resume()
-        # Wait for queue_manager to process the folder/file
-        sleep(25) # To avoid failure, if any delay in server response
 
-        # pair_state should be 'synchronized' for the folder/file
-        test_folder = self.get_dao_state_from_engine_1('/FolderB')
-        self.assertEqual(test_folder.pair_state, 'synchronized')
-        test_file = self.get_dao_state_from_engine_1('/FolderB/TestFile1.txt')
-        self.assertEqual(test_file.pair_state, 'synchronized')
+        # Wait for files to upload
+        states = self.wait_for_upload(items=['/FolderB', '/FolderB/TestFile1.txt'])
+        for state in states:
+            self.assertEqual(state.pair_state, 'synchronized')

--- a/nuxeo-drive-client/nxdrive/tests/test_engine_offline.py
+++ b/nuxeo-drive-client/nxdrive/tests/test_engine_offline.py
@@ -1,0 +1,132 @@
+'''
+Created on 11-Jul-2016
+
+@author: arameshkumar
+
+Files/folders should not sync while engine is paused due to a network error. In this test case, mock is used to simulate a network error
+
+'''
+
+from common_unit_test import UnitTestCase
+import nxdrive
+from mock import patch
+from urllib2 import URLError
+from time import sleep
+from nxdrive.client.base_automation_client import BaseAutomationClient
+
+server_online = True
+original_execute = BaseAutomationClient.execute
+original_fetch_api = BaseAutomationClient.fetch_api
+
+
+class EngineOffLineTestCase(UnitTestCase):
+
+    '''
+    1. fetch_api() and execute() methods in BaseAutomationClient are mocked to simulate network error
+    2. Files/folders should not sync while engine is paused due to a network error
+    3. Files/folders should not sync on manual pause and should sync on resume.
+    '''
+
+    def setUp(self):
+        super(EngineOffLineTestCase, self).setUp()
+        # Start engine and wait for Sync
+        self.engine_1.start()
+        self.wait_sync(wait_for_async=30)
+
+    def tearDown(self):
+        pass
+
+    def mock_fetch_api(self):
+        global server_online
+        if not server_online:
+            raise URLError("server is offline in mock_fetch_api:")
+        return original_fetch_api(self)
+
+    def mock_execute(self, *args, **kwargs):
+        global server_online
+        if not server_online and ('NuxeoDrive' in args[0] or 'Workspace' in args[0] or args[0].strip('/').endswith('/automation')):
+            # block all Nuxeo Drive APIs and also UserWorkspace.Get API only when server offline
+            raise URLError("server is offline in mock_execute:")
+        return original_execute(self, *args, **kwargs)
+
+    @patch.object(nxdrive.client.base_automation_client.BaseAutomationClient, 'fetch_api', mock_fetch_api)
+    @patch.object(nxdrive.client.base_automation_client.BaseAutomationClient, 'execute', mock_execute)
+    def test_with_mock_server_offline(self):
+
+        '''
+        1. Simulate Network Error
+        2. Create a local folder inside user folder
+        3. Create a file inside the folder
+        4. Check the pair_state and error_count for the folder/files when engine goes offline
+        5. Call original method to resume engine
+        4. Check the pair_state when engine goes online
+        '''
+
+        global server_online
+        server_online = False
+        # Wait for GetChangeSummary to call check_offline method
+        sleep(35)
+
+        # Create a folder inside user folder and a file inside the folder
+        self.local_client_1.make_folder(u'/', 'NetworkError')
+        self.local_client_1.make_file(u'/NetworkError', 'NetworkErrorFile.txt', content="test network failure")
+        # Wait for events to be handled
+        sleep(35)
+
+        # Check pair_state and error_count for the folder/file because it should not try to sync when engine is offline
+        test_folder = self.get_dao_state_from_engine_1('/NetworkError')
+        self.assertEqual(test_folder.pair_state, 'locally_created')
+        self.assertEqual(test_folder.error_count, 0)
+        test_file = self.get_dao_state_from_engine_1('/NetworkError/NetworkErrorFile.txt')
+        self.assertEqual(test_file.pair_state, 'locally_created')
+        self.assertEqual(test_file.error_count, 0)
+
+        # Stop mocking and call original method
+        global server_online
+        server_online = True
+        # Wait for queue_manager to process for the folder/file
+        sleep(60)
+
+        # pair_state should be 'synchronized' for the folder/file
+        test_folder = self.get_dao_state_from_engine_1('/NetworkError')
+        self.assertEqual(test_folder.pair_state, 'synchronized')
+        test_file = self.get_dao_state_from_engine_1('/NetworkError/NetworkErrorFile.txt')
+        self.assertEqual(test_file.pair_state, 'synchronized')
+
+    def test_with_manual_pause_resume(self):
+
+        '''
+        1. Pause the engine
+        2. Create a local folder inside user folder
+        3. Create a file inside the folder
+        4. Check the pair_state and error_count for the folder/files when engine is paused
+        5. Resume the engine
+        4. Check the pair_state when engine is resumed
+        '''
+
+        # Suspend the engine
+        self.engine_1.suspend()
+
+        # Create a folder inside user folder and a file inside the folder
+        self.local_client_1.make_folder(u'/', 'ManualPause')
+        self.local_client_1.make_file(u'/ManualPause', 'ManualPauseFile.txt', content="test manual pause and resume")
+        # Wait for events to be handled
+        sleep(35)
+
+        # queue manager will not process for the folder/file when engine is paused and
+        # database should not have entries for the folder/file
+        test_folder = self.get_dao_state_from_engine_1('/ManualPause')
+        self.assertIsNone(test_folder)
+        test_file = self.get_dao_state_from_engine_1('/ManualPause/ManualPauseFile.txt')
+        self.assertIsNone(test_file)
+
+        # Resume the engine
+        self.engine_1.resume()
+        # Wait for queue_manager to process the folder/file
+        sleep(60)
+
+        # pair_state should be 'synchronized' for the folder/file
+        test_folder = self.get_dao_state_from_engine_1('/ManualPause')
+        self.assertEqual(test_folder.pair_state, 'synchronized')
+        test_file = self.get_dao_state_from_engine_1('/ManualPause/ManualPauseFile.txt')
+        self.assertEqual(test_file.pair_state, 'synchronized')

--- a/nuxeo-drive-client/nxdrive/tests/test_engine_offline.py
+++ b/nuxeo-drive-client/nxdrive/tests/test_engine_offline.py
@@ -68,16 +68,16 @@ class EngineOffLineTestCase(UnitTestCase):
         sleep(35)
 
         # Create a folder inside user folder and a file inside the folder
-        self.local_client_1.make_folder(u'/', 'NetworkError')
-        self.local_client_1.make_file(u'/NetworkError', 'NetworkErrorFile.txt', content="test network failure")
+        self.local_client_1.make_folder('/', 'FolderA')
+        self.local_client_1.make_file('/FolderA', 'TestFile.txt', content="test network failure")
         # Wait for events to be handled
         sleep(35)
 
         # Check pair_state and error_count for the folder/file because it should not try to sync when engine is offline
-        test_folder = self.get_dao_state_from_engine_1('/NetworkError')
+        test_folder = self.get_dao_state_from_engine_1('/FolderA')
         self.assertEqual(test_folder.pair_state, 'locally_created')
         self.assertEqual(test_folder.error_count, 0)
-        test_file = self.get_dao_state_from_engine_1('/NetworkError/NetworkErrorFile.txt')
+        test_file = self.get_dao_state_from_engine_1('/FolderA/TestFile.txt')
         self.assertEqual(test_file.pair_state, 'locally_created')
         self.assertEqual(test_file.error_count, 0)
 
@@ -88,9 +88,9 @@ class EngineOffLineTestCase(UnitTestCase):
         sleep(60)
 
         # pair_state should be 'synchronized' for the folder/file
-        test_folder = self.get_dao_state_from_engine_1('/NetworkError')
+        test_folder = self.get_dao_state_from_engine_1('/FolderA')
         self.assertEqual(test_folder.pair_state, 'synchronized')
-        test_file = self.get_dao_state_from_engine_1('/NetworkError/NetworkErrorFile.txt')
+        test_file = self.get_dao_state_from_engine_1('/FolderA/TestFile.txt')
         self.assertEqual(test_file.pair_state, 'synchronized')
 
     def test_with_manual_pause_resume(self):
@@ -108,16 +108,16 @@ class EngineOffLineTestCase(UnitTestCase):
         self.engine_1.suspend()
 
         # Create a folder inside user folder and a file inside the folder
-        self.local_client_1.make_folder(u'/', 'ManualPause')
-        self.local_client_1.make_file(u'/ManualPause', 'ManualPauseFile.txt', content="test manual pause and resume")
+        self.local_client_1.make_folder('/', 'FolderB')
+        self.local_client_1.make_file('/FolderB', 'TestFile1.txt', content="test manual pause and resume")
         # Wait for events to be handled
         sleep(35)
 
         # queue manager will not process for the folder/file when engine is paused and
         # database should not have entries for the folder/file
-        test_folder = self.get_dao_state_from_engine_1('/ManualPause')
+        test_folder = self.get_dao_state_from_engine_1('/FolderB')
         self.assertIsNone(test_folder)
-        test_file = self.get_dao_state_from_engine_1('/ManualPause/ManualPauseFile.txt')
+        test_file = self.get_dao_state_from_engine_1('/FolderB/TestFile1.txt')
         self.assertIsNone(test_file)
 
         # Resume the engine
@@ -126,7 +126,7 @@ class EngineOffLineTestCase(UnitTestCase):
         sleep(60)
 
         # pair_state should be 'synchronized' for the folder/file
-        test_folder = self.get_dao_state_from_engine_1('/ManualPause')
+        test_folder = self.get_dao_state_from_engine_1('/FolderB')
         self.assertEqual(test_folder.pair_state, 'synchronized')
-        test_file = self.get_dao_state_from_engine_1('/ManualPause/ManualPauseFile.txt')
+        test_file = self.get_dao_state_from_engine_1('/FolderB/TestFile1.txt')
         self.assertEqual(test_file.pair_state, 'synchronized')


### PR DESCRIPTION
**ISSUE:** When user creates folder  during offline , DS client resumes automatically. This should be avoided.

**REASON:** If DS client resumes during the offline period, the maximum tries for the folder will be reached and the folder will be left as unsynchronized in local machine .

**FIX:** To avoid auto resume of DS client, while engine is offline.

Please review the fix and test case and merge the same 
