### PR TITLE
Cspii 11513 do not sync hidden file

### DIFF
--- a/nuxeo-drive-client/nxdrive/client/base_automation_client.py
+++ b/nuxeo-drive-client/nxdrive/client/base_automation_client.py
@@ -14,6 +14,7 @@ from urllib import urlencode
 from poster.streaminghttp import get_handlers
 from nxdrive.logging_config import get_logger
 from nxdrive.client.common import BaseClient
+from nxdrive.client.common import add_ignore_filter, remove_ignore_filter, ignore_prefixes, ignore_suffixes
 from nxdrive.client.common import DEFAULT_REPOSITORY_NAME
 from nxdrive.client.common import FILE_BUFFER_SIZE_NO_RATE_LIMIT, FILE_BUFFER_SIZE_WITH_RATE_LIMIT
 from nxdrive.client.common import safe_filename
@@ -859,6 +860,20 @@ class BaseAutomationClient(BaseClient):
         if blob_timeout is None or blob_timeout < 0:
             blob_timeout = 60
         self.blob_timeout = blob_timeout
+
+        if ignored_prefixes is not None:
+            # remove default prefixes and register with these new ones
+            fname = ignore_prefixes.func.func_name
+            func = remove_ignore_filter(fname)
+            # reregister the "ignore_prefixes filter with the new prefixes
+            add_ignore_filter(fname, prefixes=ignored_prefixes, apply_to_parent=func.apply_to_parent)
+
+        if ignored_suffixes is not None:
+            # remove default suffixes and register with these new ones
+            fname = ignore_suffixes.func.func_name
+            func = remove_ignore_filter(fname)
+            # reregister the "ignore_suffixes filter with the new suffixes
+            add_ignore_filter(fname, suffixes=ignored_suffixes, apply_to_parent=func.apply_to_parent)
 
         self.upload_tmp_dir = (upload_tmp_dir if upload_tmp_dir is not None
                                else tempfile.gettempdir())

--- a/nuxeo-drive-client/nxdrive/client/base_automation_client.py
+++ b/nuxeo-drive-client/nxdrive/client/base_automation_client.py
@@ -16,8 +16,6 @@ from nxdrive.logging_config import get_logger
 from nxdrive.client.common import BaseClient
 from nxdrive.client.common import DEFAULT_REPOSITORY_NAME
 from nxdrive.client.common import FILE_BUFFER_SIZE_NO_RATE_LIMIT, FILE_BUFFER_SIZE_WITH_RATE_LIMIT
-from nxdrive.client.common import DEFAULT_IGNORED_PREFIXES
-from nxdrive.client.common import DEFAULT_IGNORED_SUFFIXES
 from nxdrive.client.common import safe_filename
 from nxdrive.engine.activity import Action, FileAction
 from nxdrive.utils import DEVICE_DESCRIPTIONS
@@ -861,15 +859,6 @@ class BaseAutomationClient(BaseClient):
         if blob_timeout is None or blob_timeout < 0:
             blob_timeout = 60
         self.blob_timeout = blob_timeout
-        if ignored_prefixes is not None:
-            self.ignored_prefixes = ignored_prefixes
-        else:
-            self.ignored_prefixes = DEFAULT_IGNORED_PREFIXES
-
-        if ignored_suffixes is not None:
-            self.ignored_suffixes = ignored_suffixes
-        else:
-            self.ignored_suffixes = DEFAULT_IGNORED_SUFFIXES
 
         self.upload_tmp_dir = (upload_tmp_dir if upload_tmp_dir is not None
                                else tempfile.gettempdir())

--- a/nuxeo-drive-client/nxdrive/client/common.py
+++ b/nuxeo-drive-client/nxdrive/client/common.py
@@ -3,6 +3,119 @@
 import re
 import os
 import stat
+from functools import partial
+from collections import Iterable
+
+
+registry = set()
+
+
+def register(*args, **kwargs):
+    def decorator(func):
+        try:
+            apply_to_parent = kwargs['apply_to_parent']
+        except KeyError:
+            apply_to_parent = False
+        func2 = partial(func, *args, **kwargs)
+        func2.apply_to_parent = apply_to_parent
+        registry.add(func2)
+        return func2
+    return decorator
+
+
+def remove_ignore_filter(func_name):
+    partial_func = None
+    for f in registry:
+        if f.func.func_name == func_name:
+            partial_func = f
+            break
+    if partial_func:
+        registry.remove(partial_func)
+    return partial_func
+
+
+def add_ignore_filter(func, **kwargs):
+    # func could be the actual function of a partial function (from the registry)
+    if func is not None and hasattr(func, "func"):
+        func = getattr(func, "func", None)
+    if func:
+        register(**kwargs)(func)
+    return func
+
+
+@register(prefixes=(
+        '.',  # hidden Unix files
+        '~$',  # Windows lock files
+        'Thumbs.db',  # Thumbnails files
+        'Icon\r',  # Mac Icon
+        'desktop.ini',  # Icon for windows
+), apply_to_parent=True
+)
+def ignore_prefixes(client, parent, name, **kwargs):
+    # only needs the (file) name, client and parent are not used
+    prefixes = kwargs['prefixes']
+    if prefixes is None:
+        return False
+    if isinstance(prefixes, Iterable):
+        for prefix in prefixes:
+            if name.startswith(prefix):
+                return True
+    elif isinstance(prefixes, str):
+        if name.startswith(prefixes):
+            return True
+    else:
+        return False
+
+
+@register(suffixes=(
+        '~',  # editor buffers
+        '.swp',  # vim swap files
+        '.lock',  # some process use file locks
+        '.LOCK',  # other locks
+        '.part', '.crdownload', '.partial',  # partially downloaded files by browsers
+))
+def ignore_suffixes(client, parent, name, **kwargs):
+    # only needs the (file) name, client and parent are not used
+    suffixes = kwargs['suffixes']
+    if suffixes is None:
+        return False
+    if isinstance(suffixes, Iterable):
+        for suffix in suffixes:
+            if name.endswith(suffix):
+                return True
+    elif isinstance(suffixes, str):
+        if name.endswith(suffixes):
+            return True
+    else:
+        return False
+
+
+@register(prefixes=('~', '#',), suffixes=('.tmp', '#',))
+def ignore_prefix_and_suffix(client, parent, name, **kwargs):
+    # only needs the (file) name, client and parent are not used
+    prefixes = kwargs['prefixes']
+    suffixes = kwargs['suffixes']
+    if prefixes is None or suffixes is None:
+        return False
+    if len(name) < 2:
+        return False
+    if isinstance(prefixes, str) and isinstance(suffixes, str):
+        return name.startswith(prefixes) and name.endswith(suffixes)
+
+    if isinstance(prefixes, Iterable) and isinstance(suffixes, Iterable):
+        for prefix, suffix in zip(prefixes, suffixes):
+            if name.startswith(prefix) and name.endswith(suffix):
+                return True
+    return False
+
+
+def base_is_ignored(client, parent_ref, file_name):
+    grandparent_ref, dir_name = os.path.split(parent_ref)
+    if dir_name:
+        ignore = any(f(client, grandparent_ref, dir_name) for f in registry if f.apply_to_parent)
+    else:
+        ignore = False
+    return ignore or any(f(client, parent_ref, file_name) for f in registry)
 
 
 class BaseClient(object):

--- a/nuxeo-drive-client/nxdrive/client/common.py
+++ b/nuxeo-drive-client/nxdrive/client/common.py
@@ -110,12 +110,12 @@ def ignore_prefix_and_suffix(client, parent, name, **kwargs):
 
 
 def base_is_ignored(client, parent_ref, file_name):
-    grandparent_ref, dir_name = os.path.split(parent_ref)
-    if dir_name:
-        ignore = any(f(client, grandparent_ref, dir_name) for f in registry if f.apply_to_parent)
-    else:
-        ignore = False
-    return ignore or any(f(client, parent_ref, file_name) for f in registry)
+    ignore_parent = False
+    if parent_ref:
+        grandparent_ref, dir_name = os.path.split(parent_ref)
+        if dir_name:
+            ignore_parent = any(f(client, grandparent_ref, dir_name) for f in registry if f.apply_to_parent)
+    return ignore_parent or any(f(client, parent_ref, file_name) for f in registry)
 
 
 class BaseClient(object):

--- a/nuxeo-drive-client/nxdrive/client/common.py
+++ b/nuxeo-drive-client/nxdrive/client/common.py
@@ -66,22 +66,6 @@ class NotFound(Exception):
 
 DEFAULT_REPOSITORY_NAME = 'default'
 
-DEFAULT_IGNORED_PREFIXES = [
-    '.',  # hidden Unix files
-    '~$',  # Windows lock files
-    'Thumbs.db',  # Thumbnails files
-    'Icon\r',  # Mac Icon
-    'desktop.ini',  # Icon for windows
-]
-
-DEFAULT_IGNORED_SUFFIXES = [
-    '~',  # editor buffers
-    '.swp',  # vim swap files
-    '.lock',  # some process use file locks
-    '.LOCK',  # other locks
-    '.part', '.crdownload', '.partial',  # partially downloaded files by browsers
-]
-
 # Default buffer size for file upload / download and digest computation
 FILE_BUFFER_SIZE_NO_RATE_LIMIT = 1024 ** 2
 FILE_BUFFER_SIZE_WITH_RATE_LIMIT = 1024 * 128

--- a/nuxeo-drive-client/nxdrive/client/local_client.py
+++ b/nuxeo-drive-client/nxdrive/client/local_client.py
@@ -4,14 +4,13 @@ import unicodedata
 from datetime import datetime
 import hashlib
 import os
-import sys
 import shutil
 import re
 import tempfile
 from functools import wraps
-from collections import Iterable
-from functools import partial
 from nxdrive.client.common import BaseClient, UNACCESSIBLE_HASH
+from nxdrive.client.common import register, add_ignore_filter, remove_ignore_filter, \
+    ignore_prefixes, ignore_suffixes, base_is_ignored
 from nxdrive.osi import AbstractOSIntegration
 
 from nxdrive.client.base_automation_client import DOWNLOAD_TMP_FILE_PREFIX
@@ -129,22 +128,6 @@ class FileInfo(object):
         return h.hexdigest()
 
 
-registry = set()
-
-
-def register(*args, **kwargs):
-    def decorator(func):
-        try:
-            apply_to_parent = kwargs['apply_to_parent']
-        except KeyError:
-            apply_to_parent = False
-        func2 = partial(func, *args, **kwargs)
-        func2.apply_to_parent = apply_to_parent
-        registry.add(func2)
-        return func2
-    return decorator
-
-
 class LocalClient(BaseClient):
     """Client API implementation for the local file system"""
 
@@ -159,115 +142,56 @@ class LocalClient(BaseClient):
         # computation if the synchronization thread needs to be suspended
         self.check_suspended = check_suspended
 
-        cls = type(self)
         if ignored_prefixes is not None:
             # remove default prefixes and register with these new ones
-            fname = cls.ignore_prefixes.func.func_name
-            func = cls._remove_ignore_filter(fname)
+            fname = ignore_prefixes.func.func_name
+            func = remove_ignore_filter(fname)
             # reregister the "ignore_prefixes filter with the new prefixes
-            self._add_ignore_filter(fname, prefixes=ignored_prefixes, apply_to_parent=func.apply_to_parent)
+            add_ignore_filter(func, prefixes=ignored_prefixes, apply_to_parent=func.apply_to_parent)
 
         if ignored_suffixes is not None:
             # remove default suffixes and register with these new ones
-            fname = cls.ignore_suffixes.func.func_name
-            func = cls._remove_ignore_filter(fname)
+            fname = ignore_suffixes.func.func_name
+            func = remove_ignore_filter(fname)
             # reregister the "ignore_suffixes filter with the new suffixes
-            self._add_ignore_filter(fname, suffixes=ignored_suffixes, apply_to_parent=func.apply_to_parent)
+            add_ignore_filter(func, suffixes=ignored_suffixes, apply_to_parent=func.apply_to_parent)
 
         while len(base_folder) > 1 and base_folder.endswith(os.path.sep):
             base_folder = base_folder[:-1]
         self.base_folder = base_folder
         self._digest_func = digest_func
 
-    @staticmethod
-    def _remove_ignore_filter(func_name):
-        partial_func = None
-        for f in registry:
-            if f.func.func_name == func_name:
-                partial_func = f
-                break
-        if partial_func:
-            registry.remove(partial_func)
-        return partial_func
-
-    def _add_ignore_filter(self, func_name, **kwargs):
-        partial_func = getattr(self, func_name, None)
-        if partial_func:
-            register(**kwargs)(partial_func.func)
-
     @register()
     def ignore_non_existant(self, parent, name, **kwargs):
+        # 'self' here represents the context where the function is called and is used to facilitate its work; use
+        # 'duck-typing' to check for the right context.
+        # skip if called with a context which cannot compute the absolute path, e.g. missing,
+        # not derived from LocalClient, etc.
+        if self is None or not hasattr(self, '_abspath'):
+            return False
         path = self._abspath(os.path.join(parent, name))
         return not os.path.exists(path)
 
     @register()
     def ignore_guest_folder(self, parent, name, **kwargs):
+        # 'self' here represents the context where the function is called and is used to facilitate its work; use
+        # 'duck-typing' to check for the right context.
+        # skip if called with a context which cannot compute the absolute path, e.g. missing,
+        # not derived from LocalClient, etc.
+        if self is None or not hasattr(self, '_abspath'):
+            return False
         path = self._abspath(os.path.join(parent, name))
         return os.path.exists(path) and os.path.isdir(path) and name == 'Guest Folder'
-
-    @register(prefixes=(
-            '.',  # hidden Unix files
-            '~$',  # Windows lock files
-            'Thumbs.db',  # Thumbnails files
-            'Icon\r',  # Mac Icon
-            'desktop.ini',  # Icon for windows
-    ), apply_to_parent=True
-    )
-    def ignore_prefixes(self, parent, name, **kwargs):
-        prefixes = kwargs['prefixes']
-        if prefixes is None:
-            return False
-        if isinstance(prefixes, Iterable):
-            for prefix in prefixes:
-                if name.startswith(prefix):
-                    return True
-        elif isinstance(prefixes, str):
-            if name.startswith(prefixes):
-                return True
-        else:
-            return False
-
-    @register(suffixes=(
-            '~',  # editor buffers
-            '.swp',  # vim swap files
-            '.lock',  # some process use file locks
-            '.LOCK',  # other locks
-            '.part', '.crdownload', '.partial',  # partially downloaded files by browsers
-    ))
-    def ignore_suffixes(self, parent, name, **kwargs):
-        suffixes = kwargs['suffixes']
-        if suffixes is None:
-            return False
-        if isinstance(suffixes, Iterable):
-            for suffix in suffixes:
-                if name.endswith(suffix):
-                    return True
-        elif isinstance(suffixes, str):
-            if name.endswith(suffixes):
-                return True
-        else:
-            return False
-
-    @register(prefixes=('~', '#',), suffixes=('.tmp', '#',))
-    def ignore_prefix_and_suffix(self, parent, name, **kwargs):
-        prefixes = kwargs['prefixes']
-        suffixes = kwargs['suffixes']
-        if prefixes is None or suffixes is None:
-            return False
-        if len(name) < 2:
-            return False
-        if isinstance(prefixes, str) and isinstance(suffixes, str):
-            return name.startswith(prefixes) and name.endswith(suffixes)
-
-        if isinstance(prefixes, Iterable) and isinstance(suffixes, Iterable):
-            for prefix, suffix in zip(prefixes, suffixes):
-                if name.startswith(prefix) and name.endswith(suffix):
-                    return True
-        return False
 
     @register(apply_to_parent=True)
     def ignore_hidden(self, parent, name, **kwargs):
         if AbstractOSIntegration.is_windows():
+            # 'self' here represents the context where the function is called and is used to facilitate its work; use
+            # 'duck-typing' to check for the right context.
+            # skip if called with a context which cannot compute the absolute path, e.g. missing,
+            # not derived from LocalClient, etc.
+            if self is None or not hasattr(self, '_abspath') or not hasattr(self, 'get_children_ref'):
+                return False
             # NXDRIVE 465
             ref = self.get_children_ref(parent, name)
             path = self._abspath(ref)
@@ -617,24 +541,15 @@ class LocalClient(BaseClient):
 
     def manipulate_guest_filter(self, ignore_guest):
         if ignore_guest:
-            func = None
-            for f in registry:
-                if f.func.func_name == "ignore_guest_folder":
-                    func = f
-                    break
-            if func:
-                registry.remove(func)
+            remove_ignore_filter("ignore_guest_folder")
         else:
-            registry.add(self.ignore_guest_folder)
+            func = getattr(self, "ignore_guest_folder", None)
+            if func:
+                add_ignore_filter(func)
 
     def is_ignored(self, parent_ref, file_name, ignore_guest=False):
         self.manipulate_guest_filter(ignore_guest)
-        grandparent_ref, dir_name = os.path.split(parent_ref)
-        if dir_name:
-            ignore = any(f(grandparent_ref, dir_name) for f in registry if f.apply_to_parent)
-        else:
-            ignore = False
-        return ignore or any(f(self, parent_ref, file_name) for f in registry)
+        return base_is_ignored(self, parent_ref, file_name)
 
     def get_children_ref(self, parent_ref, name):
         if parent_ref == u'/':

--- a/nuxeo-drive-client/nxdrive/client/local_client.py
+++ b/nuxeo-drive-client/nxdrive/client/local_client.py
@@ -4,10 +4,13 @@ import unicodedata
 from datetime import datetime
 import hashlib
 import os
+import sys
 import shutil
 import re
 import tempfile
 from functools import wraps
+from collections import Iterable
+from functools import partial
 from nxdrive.client.common import BaseClient, UNACCESSIBLE_HASH
 from nxdrive.osi import AbstractOSIntegration
 
@@ -18,7 +21,6 @@ from nxdrive.client.common import safe_filename
 from nxdrive.client.common import NotFound
 from nxdrive.client.common import DEFAULT_IGNORED_PREFIXES
 from nxdrive.client.common import DEFAULT_IGNORED_SUFFIXES
-from nxdrive.client.common import MAX_DUPLICATES
 from nxdrive.utils import normalized_path
 from nxdrive.utils import safe_long_path
 from nxdrive.utils import guess_digest_algorithm
@@ -129,6 +131,21 @@ class FileInfo(object):
         return h.hexdigest()
 
 
+# filters for files to be ignored
+MAX_SIZE = sys.maxint
+
+registry = set()
+
+
+def register(*args, **kwargs):
+    def decorator(func):
+        func2 = partial(func, *args, **kwargs)
+        registry.add(func2)
+        print 'added %s to registry' % func
+        return func2
+    return decorator
+
+
 class LocalClient(BaseClient):
     """Client API implementation for the local file system"""
 
@@ -157,6 +174,75 @@ class LocalClient(BaseClient):
             base_folder = base_folder[:-1]
         self.base_folder = base_folder
         self._digest_func = digest_func
+
+    @register()
+    def ignore_non_existant(self, parent, name, **kwargs):
+        path = self._abspath(os.path.join(parent, name))
+        return not os.path.exists(path)
+
+    @register()
+    def ignore_guest_folder(self, parent, name, **kwargs):
+        path = self._abspath(os.path.join(parent, name))
+        return os.path.exists(path) and os.path.isdir(path) and name == 'Guest Folder'
+
+    @register(prefixes=(
+            '.',  # hidden Unix files
+            '~$',  # Windows lock files
+            'Thumbs.db',  # Thumbnails files
+            'Icon\r',  # Mac Icon
+            'desktop.ini',  # Icon for windows
+    ))
+    def ignore_prefixes(self, parent, name, **kwargs):
+        prefixes = kwargs['prefixes']
+        if prefixes is None:
+            return False
+        if isinstance(prefixes, Iterable):
+            for prefix in prefixes:
+                if name.startswith(prefix):
+                    return True
+        elif isinstance(prefixes, str):
+            if name.startswith(prefixes):
+                return True
+        else:
+            return False
+
+    @register(suffixes=(
+            '~',  # editor buffers
+            '.swp',  # vim swap files
+            '.lock',  # some process use file locks
+            '.LOCK',  # other locks
+            '.part', '.crdownload', '.partial',  # partially downloaded files by browsers
+    ))
+    def ignore_suffixes(self, parent, name, **kwargs):
+        suffixes = kwargs['suffixes']
+        if suffixes is None:
+            return False
+        if isinstance(suffixes, Iterable):
+            for suffix in suffixes:
+                if name.endswith(suffix):
+                    return True
+        elif isinstance(suffixes, str):
+            if name.endswith(suffixes):
+                return True
+        else:
+            return False
+
+    @register(prefixes=('~', '#',), suffixes=('.tmp', '#',))
+    def ignore_prefix_and_suffix(self, parent, name, **kwargs):
+        prefixes = kwargs['prefixes']
+        suffixes = kwargs['suffixes']
+        if prefixes is None or suffixes is None:
+            return False
+        if len(name) < 2:
+            return False
+        if isinstance(prefixes, str) and isinstance(suffixes, str):
+            return name.startswith(prefixes) and name.endswith(suffixes)
+
+        if isinstance(prefixes, Iterable) and isinstance(suffixes, Iterable):
+            for prefix, suffix in zip(prefixes, suffixes):
+                if name.startswith(prefix) and name.endswith(suffix):
+                    return True
+        return False
 
     def is_case_sensitive(self):
         if self._case_sensitive is None:
@@ -489,44 +575,21 @@ class LocalClient(BaseClient):
             return False
         return bool(ord(attrs[8]) & 0x20)
 
-    def is_ignored(self, parent_ref, file_name, ignore_guest=False):
-        # Add parent_ref to be able to filter on size if needed
-        ignore = False
-        # Office temp file
-        # http://support.microsoft.com/kb/211632
-        if file_name.startswith("~") and file_name.endswith(".tmp"):
-            return True
-        # Emacs auto save file
-        # http://www.emacswiki.org/emacs/AutoSave
-        if file_name.startswith("#") and file_name.endswith("#") and len(file_name) > 2:
-            return True
-        for suffix in self.ignored_suffixes:
-            if file_name.endswith(suffix):
-                ignore = True
-                break
-        for prefix in self.ignored_prefixes:
-            if file_name.startswith(prefix):
-                ignore = True
-                break
-        if ignore:
-            return True
-        if file_name == u'Guest Folder':
-            return ignore_guest
+    def manipulate_guest_filter(self, ignore_guest):
+        if ignore_guest:
+            func = None
+            for f in registry:
+                if f.func.func_name == "ignore_guest_folder":
+                    func = f
+                    break
+            if func:
+                registry.remove(func)
+        else:
+            registry.add(self.ignore_guest_folder)
 
-        if AbstractOSIntegration.is_windows():
-            # NXDRIVE-465
-            ref = self.get_children_ref(parent_ref, file_name)
-            path = self._abspath(ref)
-            if not os.path.exists(path):
-                return False
-            import win32con
-            import win32api
-            attrs = win32api.GetFileAttributes(path)
-            if attrs & win32con.FILE_ATTRIBUTE_SYSTEM == win32con.FILE_ATTRIBUTE_SYSTEM:
-                return True
-            if attrs & win32con.FILE_ATTRIBUTE_HIDDEN == win32con.FILE_ATTRIBUTE_HIDDEN:
-                return True
-        return False
+    def is_ignored(self, parent_ref, file_name, ignore_guest=False):
+        self.manipulate_guest_filter(ignore_guest)
+        return any(f(self, parent_ref, file_name) for f in registry)
 
     def get_children_ref(self, parent_ref, name):
         if parent_ref == u'/':

--- a/nuxeo-drive-client/nxdrive/client/local_client.py
+++ b/nuxeo-drive-client/nxdrive/client/local_client.py
@@ -244,6 +244,25 @@ class LocalClient(BaseClient):
                     return True
         return False
 
+    @register
+    def ignore_hidden(self, parent, name, **kwargs):
+        if AbstractOSIntegration.is_windows():
+            # NXDRIVE 465
+            ref = self.get_children_ref(parent, name)
+            path = self._abspath(ref)
+            if not os.path.exists(path):
+                return False
+
+            import win32con
+            import win32api
+
+            attrs = win32api.GetFileAttributes(path)
+            if attrs & win32con.FILE_ATTRIBUTE_SYSTEM == win32con.FILE_ATTRIBUTE_SYSTEM:
+                return True
+            if attrs & win32con.FILE_ATTRIBUTE_HIDDEN == win32con.FILE_ATTRIBUTE_HIDDEN:
+                return True
+        return False
+
     def is_case_sensitive(self):
         if self._case_sensitive is None:
             lock = self.unlock_path(self.base_folder, unlock_parent=False)

--- a/nuxeo-drive-client/nxdrive/client/local_client.py
+++ b/nuxeo-drive-client/nxdrive/client/local_client.py
@@ -139,7 +139,12 @@ registry = set()
 
 def register(*args, **kwargs):
     def decorator(func):
+        try:
+            apply_to_parent = kwargs['apply_to_parent']
+        except KeyError:
+            apply_to_parent = False
         func2 = partial(func, *args, **kwargs)
+        func2.apply_to_parent = apply_to_parent
         registry.add(func2)
         print 'added %s to registry' % func
         return func2
@@ -191,7 +196,8 @@ class LocalClient(BaseClient):
             'Thumbs.db',  # Thumbnails files
             'Icon\r',  # Mac Icon
             'desktop.ini',  # Icon for windows
-    ))
+    ), apply_to_parent=True
+    )
     def ignore_prefixes(self, parent, name, **kwargs):
         prefixes = kwargs['prefixes']
         if prefixes is None:
@@ -244,7 +250,7 @@ class LocalClient(BaseClient):
                     return True
         return False
 
-    @register
+    @register(apply_to_parent=True)
     def ignore_hidden(self, parent, name, **kwargs):
         if AbstractOSIntegration.is_windows():
             # NXDRIVE 465
@@ -608,7 +614,12 @@ class LocalClient(BaseClient):
 
     def is_ignored(self, parent_ref, file_name, ignore_guest=False):
         self.manipulate_guest_filter(ignore_guest)
-        return any(f(self, parent_ref, file_name) for f in registry)
+        grandparent_ref, dir_name = os.path.split(parent_ref)
+        if dir_name:
+            ignore = any(f(grandparent_ref, dir_name) for f in registry if f.apply_to_parent)
+        else:
+            ignore = False
+        return ignore or any(f(self, parent_ref, file_name) for f in registry)
 
     def get_children_ref(self, parent_ref, name):
         if parent_ref == u'/':

--- a/nuxeo-drive-client/nxdrive/client/local_client.py
+++ b/nuxeo-drive-client/nxdrive/client/local_client.py
@@ -163,16 +163,16 @@ class LocalClient(BaseClient):
         if ignored_prefixes is not None:
             # remove default prefixes and register with these new ones
             fname = cls.ignore_prefixes.func.func_name
-            cls._remove_ignore_filter(fname)
+            func = cls._remove_ignore_filter(fname)
             # reregister the "ignore_prefixes filter with the new prefixes
-            self._add_ignore_filter(fname, prefixes=ignored_prefixes)
+            self._add_ignore_filter(fname, prefixes=ignored_prefixes, apply_to_parent=func.apply_to_parent)
 
         if ignored_suffixes is not None:
             # remove default suffixes and register with these new ones
             fname = cls.ignore_suffixes.func.func_name
-            cls._remove_ignore_filter(fname)
+            func = cls._remove_ignore_filter(fname)
             # reregister the "ignore_suffixes filter with the new suffixes
-            self._add_ignore_filter(fname, suffixes=ignored_suffixes)
+            self._add_ignore_filter(fname, suffixes=ignored_suffixes, apply_to_parent=func.apply_to_parent)
 
         while len(base_folder) > 1 and base_folder.endswith(os.path.sep):
             base_folder = base_folder[:-1]
@@ -188,6 +188,7 @@ class LocalClient(BaseClient):
                 break
         if partial_func:
             registry.remove(partial_func)
+        return partial_func
 
     def _add_ignore_filter(self, func_name, **kwargs):
         partial_func = getattr(self, func_name, None)

--- a/nuxeo-drive-client/nxdrive/client/remote_document_client.py
+++ b/nuxeo-drive-client/nxdrive/client/remote_document_client.py
@@ -6,6 +6,7 @@ from datetime import datetime
 import os
 import urllib2
 from nxdrive.client.common import DEFAULT_REPOSITORY_NAME
+from nxdrive.client.common import base_is_ignored
 from nxdrive.client.common import safe_filename
 from nxdrive.logging_config import get_logger
 from nxdrive.client.common import NotFound
@@ -310,30 +311,13 @@ class RemoteDocumentClient(BaseAutomationClient):
             doc['path'], folderish, last_update, lastContributor,
             digestAlgorithm, digest, self.repository, doc['type'], version, doc['state'], has_blob, filename)
 
-    def _filtered_results(self, entries, fetch_parent_uid=True,
-                          parent_uid=None):
+    def _filtered_results(self, entries, fetch_parent_uid=True, parent_uid=None):
+        infos = [self._doc_to_info(d, fetch_parent_uid=fetch_parent_uid, parent_uid=parent_uid) for d in entries]
         # Filter out filenames that would be ignored by the file system client
-        # so as to be consistent.
-        filtered = []
-        for info in [self._doc_to_info(d, fetch_parent_uid=fetch_parent_uid,
-                                       parent_uid=parent_uid)
-                     for d in entries]:
-            ignore = False
-
-            for suffix in self.ignored_suffixes:
-                if info.name.endswith(suffix):
-                    ignore = True
-                    break
-
-            for prefix in self.ignored_prefixes:
-                if info.name.startswith(prefix):
-                    ignore = True
-                    break
-
-            if not ignore:
-                filtered.append(info)
-
-        return filtered
+        # so as to be consistent
+        # TODO use the parent path (instead of None) to also filter by the parent directory name, e.g.
+        # ignore files in a hidden folder
+        return [info for info in infos if not base_is_ignored(None, None, info.name)]
 
     #
     # Generic Automation features reused from nuxeolib


### PR DESCRIPTION
Note: "cleanup" commit is not related to this story..just something I changed to get a better error log.  

Refactoring breaks down the if...elif...else... in the _is_ignored_ into separate "filters", making it modular.
As a result, no need to override the method in _CPOLocalClient_ to ignore something else.
Just add another method **anywhere**  in the source code.
